### PR TITLE
Always return Elixir exception even there is no Zig stack trace 

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: ["ubuntu-latest"]
+        runs-on: ["ubuntu-22.04"]
         otp: ["24.2", "25.0"]
         elixir: ["1.13.0", "1.16.2", "1.18.0"]
         exclude:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling logic to enhance code clarity and maintainability.
	- Simplified exception generation and raising mechanisms.
	- Resolved potential scoping issues in error trace handling.
- **Chores**
	- Updated CI configuration to run on Ubuntu 22.04 for improved environment consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->