### PR TITLE
Migrate to Zig 0.15.1

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -66,7 +66,8 @@ jobs:
       - name: Run tests (example with gdb)
         working-directory: ./kinda_example
         run: |
-          apt install -y gdb
+          sudo apt update
+          sudo apt install -y gdb
           bash ../scripts/gdb.sh test
       - name: Run tests (example)
         working-directory: ./kinda_example

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Run tests (example with gdb)
         working-directory: ./kinda_example
         run: |
+          apt install -y gdb
           bash ../scripts/gdb.sh test
       - name: Run tests (example)
         working-directory: ./kinda_example

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Check formatting of Elixir
         working-directory: ./kinda_example
         run: mix format --check-formatted
+      - name: Run tests (example with gdb)
+        working-directory: ./kinda_example
+        run: |
+          bash scripts/gdb.sh test
       - name: Run tests (example)
         working-directory: ./kinda_example
         run: |

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Run tests
         run: |
           mix test
+      - name: Run tests with stacktrace
+        run: |
+          mix test
+        env:
+          KINDA_PRINT_STACKTRACE: 1
       - name: Install dependencies (example)
         working-directory: ./kinda_example
         run: mix deps.get

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -57,11 +57,6 @@ jobs:
       - name: Run tests
         run: |
           mix test
-      - name: Run tests with stacktrace
-        run: |
-          mix test
-        env:
-          KINDA_PRINT_STACKTRACE: 1
       - name: Install dependencies (example)
         working-directory: ./kinda_example
         run: mix deps.get
@@ -72,6 +67,12 @@ jobs:
         working-directory: ./kinda_example
         run: |
           mix test --force
+      - name: Run tests (example with stacktrace)
+        working-directory: ./kinda_example
+        run: |
+          mix test
+        env:
+          KINDA_PRINT_STACKTRACE: 1
       - name: Precompile
         working-directory: ./kinda_example
         env:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Check formatting of Elixir
         working-directory: ./kinda_example
         run: mix format --check-formatted
+      - name: Check formatting of Zig
+        run: |
+          zig fmt --check src
+          zig fmt --check kinda_example/native/zig-src
       - name: Run tests (example with gdb)
         working-directory: ./kinda_example
         run: |

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Zig
         uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.14.1
+          version: 0.15.1
       - uses: seanmiddleditch/gha-setup-ninja@master
       - name: Restore dependencies cache
         uses: actions/cache@v3

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run tests (example with gdb)
         working-directory: ./kinda_example
         run: |
-          bash scripts/gdb.sh test
+          bash ../scripts/gdb.sh test
       - name: Run tests (example)
         working-directory: ./kinda_example
         run: |

--- a/kinda_example/build.zig
+++ b/kinda_example/build.zig
@@ -5,16 +5,20 @@ const os = builtin.os.tag;
 pub fn build(b: *std.Build) void {
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const lib = b.addSharedLibrary(.{
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = b.addLibrary(.{
         .name = "KindaExampleNIF",
-        .root_source_file = b.path("native/zig-src/main.zig"),
-        .optimize = .Debug,
-        .target = b.standardTargetOptions(.{}),
+        .linkage = .dynamic,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("native/zig-src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     const kinda = b.dependencyFromBuildZig(@import("kinda"), .{});
     lib.root_module.addImport("kinda", kinda.module("kinda"));
-    lib.root_module.addImport("erl_nif", kinda.module("erl_nif"));
-    lib.root_module.addImport("beam", kinda.module("beam"));
     if (os.isDarwin()) {
         lib.root_module.addRPathSpecial("@loader_path");
     } else {

--- a/kinda_example/native/zig-src/main.zig
+++ b/kinda_example/native/zig-src/main.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
-const beam = @import("beam");
 const kinda = @import("kinda");
-const e = @import("erl_nif");
-const capi = @import("prelude.zig");
+const beam = kinda.beam;
+const e = kinda.erl_nif;
+const capi = @import("prelude.zig").c;
 const root_module = "Elixir.KindaExample.NIF";
 const Kinds = struct {
     const CInt = kinda.ResourceKind(c_int, root_module ++ ".CInt");

--- a/kinda_example/native/zig-src/prelude.zig
+++ b/kinda_example/native/zig-src/prelude.zig
@@ -2,4 +2,3 @@ pub const c = @cImport({
     @cDefine("_NO_CRT_STDIO_INLINE", "1");
     @cInclude("wrapper.h");
 });
-pub usingnamespace c;

--- a/kinda_example/test/kinda_example_test.exs
+++ b/kinda_example/test/kinda_example_test.exs
@@ -8,7 +8,7 @@ defmodule KindaExampleTest do
              NIF.kinda_example_add(1, 2) |> Native.to_term()
 
     assert match?(
-             %Kinda.CallError{message: "Fail to fetch argument #2", error_return_trace: _},
+             %Kinda.CallError{message: "Fail to fetch argument #2"},
              catch_error(NIF.kinda_example_add(1, "2"))
            )
   end
@@ -19,20 +19,15 @@ defmodule KindaExampleTest do
              |> NIF."Elixir.KindaExample.NIF.CInt.primitive"()
 
     e = catch_error(NIF."Elixir.KindaExample.NIF.StrInt.make"(1))
-    assert Exception.message(e) =~ "Function clause error\n#{IO.ANSI.reset()}"
+    assert Exception.message(e) =~ "Function clause error\n"
 
     err = catch_error(NIF."Elixir.KindaExample.NIF.StrInt.make"(1))
     # only test this on macOS, it will crash on Linux
     txt = Exception.message(err)
 
-    if System.get_env("KINDA_DUMP_STACK_TRACE") == "1" do
-      assert txt =~ "src/beam.zig"
-      assert txt =~ "kinda_example/native/zig-src/main.zig"
-    else
-      assert txt =~ "to see the full stack trace, set KINDA_DUMP_STACK_TRACE=1"
-    end
+    assert txt =~ "to see the full stack trace, set KINDA_DUMP_STACK_TRACE=1"
 
-    assert match?(%Kinda.CallError{message: "Function clause error", error_return_trace: _}, err)
+    assert match?(%Kinda.CallError{message: "Function clause error"}, err)
 
     assert 1 ==
              NIF."Elixir.KindaExample.NIF.StrInt.make"("1")

--- a/lib/kinda/error/nif_call.ex
+++ b/lib/kinda/error/nif_call.ex
@@ -1,5 +1,5 @@
 defmodule Kinda.CallError do
-  defexception [:message, :error_return_trace]
+  defexception [:message]
 
   @impl true
   def message(t) do
@@ -7,8 +7,7 @@ defmodule Kinda.CallError do
 
     """
     #{t.message}
-    #{IO.ANSI.reset()}
-    #{t.error_return_trace || notice}
+    #{notice}
     """
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Kinda.MixProject do
   def project do
     [
       app: :kinda,
-      version: "0.10.4-dev",
+      version: "0.10.5-dev",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/scripts/gdb.sh
+++ b/scripts/gdb.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# run this script to run `mix test` under gdb
+# erlang's executable is not directly run so we dry-run an elixir command to get the full command and then run it under gdb
+
+set -e
+ROOT_DIR=$(elixir --eval ":code.root_dir() |> IO.puts()")
+VERSION=$(elixir --eval ":erlang.system_info(:version) |> IO.puts()")
+export BINDIR=$ROOT_DIR/erts-$VERSION/bin
+EXE=$BINDIR/erlexec
+echo "ROOT_DIR: $ROOT_DIR"
+echo "VERSION: $VERSION"
+echo "EXE: $EXE"
+FULL=$(ELIXIR_CLI_DRY_RUN=1 mix "$@")
+FULL=${FULL/erl/${EXE}}
+echo "FULL: $FULL"
+gdb --args $FULL

--- a/scripts/gdb.sh
+++ b/scripts/gdb.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
-# run this script to run `mix test` under gdb
-# erlang's executable is not directly run so we dry-run an elixir command to get the full command and then run it under gdb
-
 set -e
+
 ROOT_DIR=$(elixir --eval ":code.root_dir() |> IO.puts()")
 VERSION=$(elixir --eval ":erlang.system_info(:version) |> IO.puts()")
 export BINDIR=$ROOT_DIR/erts-$VERSION/bin
 EXE=$BINDIR/erlexec
+
 echo "ROOT_DIR: $ROOT_DIR"
 echo "VERSION: $VERSION"
 echo "EXE: $EXE"
+
 FULL=$(ELIXIR_CLI_DRY_RUN=1 mix "$@")
 FULL=${FULL/erl/${EXE}}
 echo "FULL: $FULL"
-gdb --args $FULL
+
+# Run under GDB with automated backtrace
+gdb -ex "run" -ex "bt" -ex "quit" --args $FULL

--- a/src/beam.zig
+++ b/src/beam.zig
@@ -1408,7 +1408,8 @@ pub fn raise_assertion_error(env_: env) term {
 pub fn make_exception(env_: env, exception_module: []const u8, err: anyerror, error_trace: ?*std.builtin.StackTrace) term {
     const erl_err = make_slice(env_, @errorName(err));
     if (error_trace) |trace| {
-        if (std.posix.getenv("KINDA_DUMP_STACK_TRACE") != null) {
+        const KINDA_DUMP_STACK_TRACE = std.process.getEnvVarOwned(allocator, "KINDA_DUMP_STACK_TRACE") catch null;
+        if (KINDA_DUMP_STACK_TRACE != null) {
             std.debug.dumpStackTrace(trace.*);
         }
     }

--- a/src/beam.zig
+++ b/src/beam.zig
@@ -1403,8 +1403,6 @@ pub fn raise_assertion_error(env_: env) term {
     return e.enif_raise_exception(env_, make_atom(env_, assert_slice));
 }
 
-
-
 pub fn make_exception(env_: env, exception_module: []const u8, err: anyerror, error_trace: ?*std.builtin.StackTrace) term {
     const erl_err = make_slice(env_, @errorName(err));
     if (error_trace) |trace| {

--- a/src/beam.zig
+++ b/src/beam.zig
@@ -1408,8 +1408,9 @@ pub fn raise_assertion_error(env_: env) term {
 pub fn make_exception(env_: env, exception_module: []const u8, err: anyerror, error_trace: ?*std.builtin.StackTrace) term {
     const erl_err = make_slice(env_, @errorName(err));
     if (error_trace) |trace| {
-        const KINDA_DUMP_STACK_TRACE = std.process.getEnvVarOwned(allocator, "KINDA_DUMP_STACK_TRACE") catch null;
-        if (KINDA_DUMP_STACK_TRACE != null) {
+        var value: [256]u8 = undefined;
+        var value_size: usize = value.len;
+        if (e.enif_getenv("KINDA_DUMP_STACK_TRACE", &value[0], &value_size) == 0) {
             std.debug.dumpStackTrace(trace.*);
         }
     }

--- a/src/erl_nif.zig
+++ b/src/erl_nif.zig
@@ -17,10 +17,6 @@
 //! refer to the [erlang documentation](https://erlang.org/doc/man/erl_nif.html)
 //! for available functions
 
-pub const e = @cImport({
+pub const c = @cImport({
     @cInclude("erl_nif.h");
 });
-
-pub const ErlNifTerm = e.ERL_NIF_TERM;
-
-pub usingnamespace e;

--- a/src/kinda.zig
+++ b/src/kinda.zig
@@ -1,5 +1,6 @@
-const beam = @import("beam");
-const e = @import("erl_nif");
+pub const beam = @import("beam");
+pub const erl_nif = @import("erl_nif").c;
+const e = erl_nif;
 const std = @import("std");
 pub const result = @import("result.zig");
 
@@ -113,11 +114,11 @@ pub fn ResourceKind(comptime ElementType: type, comptime module_name_: anytype) 
         }
         fn dump(env: beam.env, _: c_int, args: [*c]const beam.term) !beam.term {
             const v: T = resource.fetch(env, args[0]) catch return beam.Error.@"Fail to fetch primitive";
-            var buffer = try std.ArrayList(u8).initCapacity(std.heap.page_allocator, 100);
+            var buffer = try std.array_list.Managed(u8).initCapacity(std.heap.page_allocator, 100);
             defer buffer.deinit();
             const format_string = switch (@typeInfo(T)) {
                 .@"pointer" => "{*}\n",
-                else => "{?}\n",
+                else => "{}\n",
             };
             try std.fmt.format(buffer.writer(), format_string, .{v});
             return beam.make_slice(env, buffer.items);
@@ -306,7 +307,7 @@ pub fn BangFunc(comptime Kinds: anytype, c: anytype, comptime name: anytype) typ
             var c_args: VariadicArgs() = undefined;
             inline for (FTI.params, args, 0..) |p, arg, i| {
                 const ArgKind = getKind(p.type.?);
-                c_args[i] = ArgKind.resource.fetch(env, arg) catch return @field(beam.ArgumentError, "Fail to fetch argument #" ++ std.fmt.comptimePrint("{?}", .{i + 1}));
+                c_args[i] = ArgKind.resource.fetch(env, arg) catch return @field(beam.ArgumentError, "Fail to fetch argument #" ++ std.fmt.comptimePrint("{d}", .{i + 1}));
             }
             const rt = FTI.return_type.?;
             if (rt == void) {

--- a/src/kinda.zig
+++ b/src/kinda.zig
@@ -10,13 +10,13 @@ pub const OpaqueStructType = struct {
     const Accessor: type = struct { maker: OpaqueMaker, offset: usize };
     const ArrayType = ?*anyopaque;
     const PtrType = ?*anyopaque;
-    storage: std.ArrayList(u8) = std.ArrayList(u8).init(beam.allocator),
+    storage: std.array_list.AlignedManaged(u8, null) = std.array_list.Managed(u8).init(beam.allocator),
     finalized: bool, // if it is finalized, can't append more fields to it. Only finalized struct can be addressed.
     accessors: std.ArrayList(Accessor),
 };
 
 pub const OpaqueField = extern struct {
-    storage: std.ArrayList(u8),
+    storage: std.array_list.AlignedManaged(u8, null),
     maker: type = OpaqueMaker,
 };
 
@@ -118,7 +118,7 @@ pub fn ResourceKind(comptime ElementType: type, comptime module_name_: anytype) 
             defer buffer.deinit();
             const format_string = switch (@typeInfo(T)) {
                 .@"pointer" => "{*}\n",
-                else => "{}\n",
+                else => "{any}\n",
             };
             try std.fmt.format(buffer.writer(), format_string, .{v});
             return beam.make_slice(env, buffer.items);

--- a/src/kinda.zig
+++ b/src/kinda.zig
@@ -117,7 +117,7 @@ pub fn ResourceKind(comptime ElementType: type, comptime module_name_: anytype) 
             var buffer = try std.array_list.Managed(u8).initCapacity(std.heap.page_allocator, 100);
             defer buffer.deinit();
             const format_string = switch (@typeInfo(T)) {
-                .@"pointer" => "{*}\n",
+                .pointer => "{*}\n",
                 else => "{any}\n",
             };
             try std.fmt.format(buffer.writer(), format_string, .{v});
@@ -222,7 +222,7 @@ pub fn BangFunc(comptime Kinds: anytype, c: anytype, comptime name: anytype) typ
         fn getKind(comptime t: type) type {
             for (Kinds) |kind| {
                 switch (@typeInfo(t)) {
-                    .@"pointer" => {
+                    .pointer => {
                         if (t == kind.Ptr.T) {
                             return kind.Ptr;
                         }

--- a/src/result.zig
+++ b/src/result.zig
@@ -1,11 +1,11 @@
 const beam = @import("beam");
-const e = @import("erl_nif");
+const e = @import("erl_nif").c;
 const std = @import("std");
 
 pub fn nif_with_flags(comptime name: [*c]const u8, comptime arity: usize, comptime f: anytype, comptime flags: u32) type {
     const ns = "Elixir.";
     return struct {
-        fn exported(env: beam.env, n: c_int, args: [*c]const beam.term) callconv(.C) beam.term {
+        fn exported(env: beam.env, n: c_int, args: [*c]const beam.term) callconv(.c) beam.term {
             return f(env, n, args) catch |err| {
                 const ert = @errorReturnTrace();
                 return beam.raise_exception(env, ns ++ "Kinda.CallError", err, ert);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Consistent, simplified NIF error messages with a clear hint to set KINDA_DUMP_STACK_TRACE=1.
  - Debug tooling: GDB runner script and CI test step that capture/backtrace on failures; CI test runs now optionally print stack traces.

- **Refactor**
  - Modernized native build/runtime interfaces and made native imports more directly available.
  - Simplified stack-trace handling and dumping logic.

- **Tests**
  - Updated tests to match revised error messages and stack-trace behavior.

- **Chores**
  - CI: bumped Zig setup to 0.15.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->