### PR TITLE
Always dump stack trace to binary term

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -79,18 +79,6 @@ jobs:
         working-directory: ./kinda_example
         run: |
           mix test --force
-      - name: Run tests (example with gdb and stacktrace)
-        working-directory: ./kinda_example
-        run: |
-          bash ../scripts/gdb.sh test
-        env:
-          KINDA_DUMP_STACK_TRACE: 1
-      - name: Run tests (example with stacktrace)
-        working-directory: ./kinda_example
-        run: |
-          mix test
-        env:
-          KINDA_DUMP_STACK_TRACE: 1
       - name: Precompile
         working-directory: ./kinda_example
         env:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           mix test
         env:
-          KINDA_PRINT_STACKTRACE: 1
+          KINDA_DUMP_STACK_TRACE: 1
       - name: Precompile
         working-directory: ./kinda_example
         env:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -41,7 +41,12 @@ jobs:
           path: deps
           key: ${{ runner.os }}-mix-kinda-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-kinda-
-      # Example project's deps cache shouldn't be restored because zig files may change
+      - name: Restore dependencies cache
+        uses: actions/cache@v3
+        with:
+          path: ./kinda_example/deps
+          key: ${{ runner.os }}-mix-example-${{ hashFiles('**/mix.exs') }}
+          restore-keys: ${{ runner.os }}-mix-example-
       - name: Install dependencies
         run: mix deps.get
       - name: Check formatting of Elixir

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,9 +11,6 @@ concurrency:
   group: manx-build-and-test-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  KINDA_PRINT_LINKAGES: 1
-
 jobs:
   build:
     name: otp${{matrix.otp}}-ex${{matrix.elixir}} / ${{matrix.runs-on}}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -79,16 +79,16 @@ jobs:
         working-directory: ./kinda_example
         run: |
           mix test --force
-      - name: Run tests (example with stacktrace)
-        working-directory: ./kinda_example
-        run: |
-          mix test
-        env:
-          KINDA_DUMP_STACK_TRACE: 1
       - name: Run tests (example with gdb and stacktrace)
         working-directory: ./kinda_example
         run: |
           bash ../scripts/gdb.sh test
+        env:
+          KINDA_DUMP_STACK_TRACE: 1
+      - name: Run tests (example with stacktrace)
+        working-directory: ./kinda_example
+        run: |
+          mix test
         env:
           KINDA_DUMP_STACK_TRACE: 1
       - name: Precompile

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -25,7 +25,7 @@ jobs:
           - otp: "24.2"
             elixir: "1.18.0"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -67,11 +67,13 @@ jobs:
         run: |
           zig fmt --check src
           zig fmt --check kinda_example/native/zig-src
+      - name: Install gdb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdb
       - name: Run tests (example with gdb)
         working-directory: ./kinda_example
         run: |
-          sudo apt update
-          sudo apt install -y gdb
           bash ../scripts/gdb.sh test
       - name: Run tests (example)
         working-directory: ./kinda_example
@@ -81,6 +83,12 @@ jobs:
         working-directory: ./kinda_example
         run: |
           mix test
+        env:
+          KINDA_DUMP_STACK_TRACE: 1
+      - name: Run tests (example with gdb and stacktrace)
+        working-directory: ./kinda_example
+        run: |
+          bash ../scripts/gdb.sh test
         env:
           KINDA_DUMP_STACK_TRACE: 1
       - name: Precompile

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -44,12 +44,7 @@ jobs:
           path: deps
           key: ${{ runner.os }}-mix-kinda-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-kinda-
-      - name: Restore dependencies cache
-        uses: actions/cache@v3
-        with:
-          path: ./kinda_example/deps
-          key: ${{ runner.os }}-mix-example-${{ hashFiles('**/mix.exs') }}
-          restore-keys: ${{ runner.os }}-mix-example-
+      # Example project's deps cache shouldn't be restored because zig files may change
       - name: Install dependencies
         run: mix deps.get
       - name: Check formatting of Elixir

--- a/kinda_example/test/kinda_example_test.exs
+++ b/kinda_example/test/kinda_example_test.exs
@@ -8,7 +8,7 @@ defmodule KindaExampleTest do
              NIF.kinda_example_add(1, 2) |> Native.to_term()
 
     assert match?(
-             %Kinda.CallError{message: "Fail to fetch argument #2"},
+             %Kinda.CallError{message: "Fail to fetch argument #2", error_return_trace: _},
              catch_error(NIF.kinda_example_add(1, "2"))
            )
   end
@@ -19,15 +19,15 @@ defmodule KindaExampleTest do
              |> NIF."Elixir.KindaExample.NIF.CInt.primitive"()
 
     e = catch_error(NIF."Elixir.KindaExample.NIF.StrInt.make"(1))
-    assert Exception.message(e) =~ "Function clause error\n"
+    assert Exception.message(e) =~ "Function clause error\n#{IO.ANSI.reset()}"
 
     err = catch_error(NIF."Elixir.KindaExample.NIF.StrInt.make"(1))
     # only test this on macOS, it will crash on Linux
     txt = Exception.message(err)
 
-    assert txt =~ "to see the full stack trace, set KINDA_DUMP_STACK_TRACE=1"
-
-    assert match?(%Kinda.CallError{message: "Function clause error"}, err)
+    assert txt =~ "src/beam.zig"
+    assert txt =~ "kinda_example/native/zig-src/main.zig"
+    assert match?(%Kinda.CallError{message: "Function clause error", error_return_trace: _}, err)
 
     assert 1 ==
              NIF."Elixir.KindaExample.NIF.StrInt.make"("1")

--- a/lib/kinda/error/nif_call.ex
+++ b/lib/kinda/error/nif_call.ex
@@ -1,13 +1,10 @@
 defmodule Kinda.CallError do
-  defexception [:message]
+  defexception [:message, :error_return_trace]
 
   @impl true
-  def message(t) do
-    notice = "to see the full stack trace, set KINDA_DUMP_STACK_TRACE=1"
+  def message(%{message: msg, error_return_trace: nil}), do: msg
 
-    """
-    #{t.message}
-    #{notice}
-    """
+  def message(%{message: msg, error_return_trace: trace}) do
+    "#{msg}\n#{IO.ANSI.reset()}#{trace}"
   end
 end

--- a/src/beam.zig
+++ b/src/beam.zig
@@ -1408,10 +1408,7 @@ pub fn format_stack_trace(st: std.builtin.StackTrace, writer: *std.io.Writer) st
     const debug_info = std.debug.getSelfDebugInfo() catch |err| {
         return writer.print("\nUnable to print stack trace: Unable to open debug info: {s}\n", .{@errorName(err)});
     };
-    // we don't detect TTY here, because Zig's implementation of that use getenv which can lead to segfaults on glibc linux
-    std.debug.writeStackTrace(st, writer, debug_info, .no_color) catch |err| {
-        try writer.print("Unable to print stack trace: {s}\n", .{@errorName(err)});
-    };
+    try @import("debug.zig").formatStackTrace(writer, st, debug_info, "  ");
 }
 fn writeStackTraceToBuffer(
     environment: env,

--- a/src/beam.zig
+++ b/src/beam.zig
@@ -1420,7 +1420,7 @@ fn writeStackTraceToBuffer(
     var buffer = std.array_list.Managed(u8).init(allocator);
     defer buffer.deinit();
     var adapted = buffer.writer().adaptToNewApi(&.{});
-    try stack_trace.format(&adapted.new_interface);
+    try format_stack_trace(stack_trace, &adapted.new_interface);
     return make_slice(environment, buffer.items);
 }
 

--- a/src/beam.zig
+++ b/src/beam.zig
@@ -1409,7 +1409,7 @@ pub fn format_stack_trace(st: std.builtin.StackTrace, writer: *std.io.Writer) st
         return writer.print("\nUnable to print stack trace: Unable to open debug info: {s}\n", .{@errorName(err)});
     };
     // we don't detect TTY here, because Zig's implementation of that use getenv which can lead to segfaults on glibc linux
-    std.debug.writeStackTrace(st, writer, debug_info, .{ .no_color = true }) catch |err| {
+    std.debug.writeStackTrace(st, writer, debug_info, .no_color) catch |err| {
         try writer.print("Unable to print stack trace: {s}\n", .{@errorName(err)});
     };
 }

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const beam = @import("beam.zig");
+const SelfInfo = std.debug.SelfInfo;
+
+var self_debug_info: ?SelfInfo = null;
+
+fn formatEmptyTraceItem(writer: anytype) !void {
+    try writer.writeAll("<unknown>");
+}
+
+fn formatTraceItem(writer: anytype, debug_info: *SelfInfo, address: usize) !void {
+    const module = debug_info.getModuleForAddress(address) catch {
+        try formatEmptyTraceItem(writer);
+        return;
+    };
+    //defer module.deinit(debug_info_allocator.?);
+
+    const symbol_info = module.getSymbolAtAddress(std.heap.c_allocator, address) catch {
+        try formatEmptyTraceItem(writer);
+        return;
+    };
+
+    if (symbol_info.source_location) |loc| {
+        try writer.print("{s}:{d}:{d}", .{
+            loc.file_name,
+            loc.line,
+            loc.column,
+        });
+    } else {
+        try writer.writeAll("<unknown>");
+    }
+
+    try writer.print(" ({s})", .{symbol_info.name});
+    try writer.print(" [{s}]", .{symbol_info.compile_unit_name});
+}
+
+pub fn formatStackTrace(
+    writer: anytype,
+    stacktrace: std.builtin.StackTrace,
+    debug_info: *SelfInfo,
+    indent: []const u8,
+) !void {
+    if (builtin.strip_debug_info) {
+        try writer.writeAll("<debug info stripped>\n");
+        return;
+    }
+
+    var frame_index: usize = 0;
+    var frames_left: usize = @min(stacktrace.index, stacktrace.instruction_addresses.len);
+
+    while (frames_left != 0) : ({
+        frames_left -= 1;
+        frame_index = (frame_index + 1) % stacktrace.instruction_addresses.len;
+    }) {
+        try writer.writeAll(indent);
+        try writer.print("#{d} ", .{frames_left});
+
+        const return_address = stacktrace.instruction_addresses[frame_index];
+        try formatTraceItem(writer, debug_info, return_address -| 1);
+
+        try writer.writeAll("\n");
+    }
+}

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -14,9 +14,8 @@ fn formatTraceItem(writer: anytype, debug_info: *SelfInfo, address: usize) !void
         try formatEmptyTraceItem(writer);
         return;
     };
-    //defer module.deinit(debug_info_allocator.?);
 
-    const symbol_info = module.getSymbolAtAddress(std.heap.c_allocator, address) catch {
+    const symbol_info = module.getSymbolAtAddress(beam.allocator, address) catch {
         try formatEmptyTraceItem(writer);
         return;
     };

--- a/src/kinda.zig
+++ b/src/kinda.zig
@@ -10,13 +10,13 @@ pub const OpaqueStructType = struct {
     const Accessor: type = struct { maker: OpaqueMaker, offset: usize };
     const ArrayType = ?*anyopaque;
     const PtrType = ?*anyopaque;
-    storage: std.array_list.AlignedManaged(u8, null) = std.array_list.Managed(u8).init(beam.allocator),
+    storage: std.array_list.Managed(u8) = std.array_list.Managed(u8).init(beam.allocator),
     finalized: bool, // if it is finalized, can't append more fields to it. Only finalized struct can be addressed.
     accessors: std.ArrayList(Accessor),
 };
 
 pub const OpaqueField = extern struct {
-    storage: std.array_list.AlignedManaged(u8, null),
+    storage: std.array_list.Managed(u8),
     maker: type = OpaqueMaker,
 };
 


### PR DESCRIPTION
getenv() is not thread-safe in glibc—if another thread (e.g., Python’s setenv()) modifies the environment concurrently, it can corrupt memory or crash due to reallocation of environment variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exceptions may include an optional returned stack trace, now formatted for clearer display.

* **Bug Fixes**
  * Error messages append ANSI reset and include relevant source path information when a trace is present.

* **Tests**
  * Tests adjusted to verify presence/format of returned traces and updated expected messages.

* **Chores**
  * CI workflow updated: newer checkout action, consolidated caches, added dedicated gdb install step, and removed redundant test flags/steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->